### PR TITLE
Adding OpenBSD support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -71,6 +71,36 @@
             }
           }
         ],
+        [
+          'OS=="openbsd"',
+          {
+            "sources": [
+              "src/linux/idle.cc"
+            ],
+            "variables": {
+	            "pkg-config": "pkg-config"
+            },
+            "sources": [
+              "src/linux/idle.cc"
+            ],
+	    "include_dirs": [
+		"/usr/X11R6/include"
+	    ],
+            "direct_dependent_settings": {
+              "cflags": [
+                "<!@(<(pkg-config) --cflags x11 xext xscrnsaver)",
+              ],
+            },
+            "link_settings": {
+              "ldflags": [
+                "<!@(<(pkg-config) --libs-only-other --libs-only-L x11 xext xscrnsaver)",
+              ],
+              "libraries": [
+                "<!@(<(pkg-config) --libs-only-l x11 xext xscrnsaver)",
+              ]
+            }
+          }
+        ],
 	[
           'OS=="win"',
           {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "linux",
     "darwin",
     "win32",
-    "freebsd"
+    "freebsd",
+    "openbsd"
   ],
   "engines": {
     "node": ">=7.9.0"


### PR DESCRIPTION
Small tweaks to bindings.gyp and package.json to allow building on OpenBSD. Required a slightly different include path from FreeBSD.

`yarn test` passes successfully on OpenBSD 6.6-current. Is there any other testing that I should perform?